### PR TITLE
Use parameterized queries for NOTIFY commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,20 @@ pgEars.notify('mychannel', {key: 'value'}, (err) => {
 })
 ```
 
+## Use safe identifiers as channel names
+
+:warning: Channel names in postgresql are `identifiers`, just like the name of a table or a column.
+Please refer to the offical postgresql documentation about valid [identifiers](https://www.postgresql.org/docs/current/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS).
+
+node-postgres does not currently allows channel names to be parameterized to avoid sql-injection attacks.
+
+See node-postgres [issue #1258](https://github.com/brianc/node-postgres/issues/1258) for details.
+
+**pg-ears performs no validation or sanitation on the channel names and they are inserted into the sql queries as-is.**
+
+On the other hand, payloads of your notifications are json encoded and decoded automatically by pg-ears and passed using safe parameterized queries.
+
+
 ## license
 
 MIT © [Andrew Carpenter](https://github.com/doesdev)

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = (opts) => {
         testClient = new Pg(opts)
         testClient.connect((err) => {
           if (err) return setTimeout((err) => retry(err), checkInterval)
-          testClient.query(`NOTIFY ${channel}, 'pg-ears-test';`, (err) => {
+          testClient.query('SELECT pg_notify($1, $2)', [channel, 'pg-ears-test'], (err) => {
             if (err) return setTimeout((err) => retry(err), checkInterval)
             if (testClient && testClient.end) testClient.end()
             setTimeout(checkConnection, checkInterval)
@@ -66,7 +66,7 @@ module.exports = (opts) => {
     payload = JSON.stringify(payload)
     client.connect((err) => {
       if (err) return cb(err)
-      client.query(`NOTIFY ${channel}, '${payload}';`, (e) => {
+      client.query('SELECT pg_notify($1, $2)', [channel, payload], (e) => {
         if (e) return cb(e)
         if (client && client.end) client.end()
       })


### PR DESCRIPTION
- Switch NOTIFY statements to pg_notify() function calls, which support
  parameterized queries.
- Add a big warning in the README about channel names, which cannot be
  fully parameterized at the moment (there is no pg_listen()).